### PR TITLE
Fix Clippy warning redundant_clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -244,7 +244,7 @@ fn prepare_command(command: &[String]) -> Vec<String> {
 
 fn quote(text: &str) -> String {
     if text.contains(' ') {
-        format!("\"{}\"", text).to_string()
+        format!("\"{}\"", text)
     } else {
         text.to_owned()
     }


### PR DESCRIPTION
`format!` macro already provides a String, so calling `to_string` is not needed here.

This should at least clear the error emerging from Clippy in CI.