### PR TITLE
#13: Add option for custom log path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "shawl"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ctrlc",
  "flexi_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shawl"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["mtkennerly <mtkennerly@gmail.com>"]
 edition = "2018"
 description = "Windows service wrapper for arbitrary commands"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,10 @@ struct CommonOpts {
     #[structopt(long)]
     no_log_cmd: bool,
 
+    /// Write log file to a custom directory. This directory will be created if it doesn't exist.
+    #[structopt(long)]
+    log_dir: Option<String>,
+
     /// Command to run as a service
     #[structopt(required(true), last(true))]
     command: Vec<String>,
@@ -100,7 +104,7 @@ struct Cli {
     sub: Subcommand,
 }
 
-fn prepare_logging(name: &str, console: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn prepare_logging(name: &str, log_dir: Option<String>, console: bool) -> Result<(), Box<dyn std::error::Error>> {
     let mut exe_dir = std::env::current_exe()?;
     exe_dir.pop();
 
@@ -124,6 +128,11 @@ fn prepare_logging(name: &str, console: bool) -> Result<(), Box<dyn std::error::
             )
         })
         .format_for_stderr(|w, _now, record| write!(w, "[{}] {}", record.level(), &record.args()));
+
+    // Set custom log directory
+    if let Some(dir) = log_dir {
+        logger = logger.o_directory(Some(dir));
+    }
 
     if console {
         logger = logger.duplicate_to_stderr(flexi_logger::Duplicate::Info);
@@ -238,6 +247,10 @@ fn construct_shawl_run_args(name: &str, cwd: &Option<String>, opts: &CommonOpts)
     if opts.no_log_cmd {
         shawl_args.push("--no-log-cmd".to_string());
     }
+    if let Some(log_dir) = &opts.log_dir {
+        shawl_args.push("--log-dir".to_string());
+        shawl_args.push(quote(&log_dir));
+    }
     if opts.pass_start_args {
         shawl_args.push("--pass-start-args".to_string());
     }
@@ -270,7 +283,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Subcommand::Add { name, .. } => name,
             Subcommand::Run { name, .. } => name,
         };
-        prepare_logging(&name, console)?;
+        let log_dir = match cli.clone().sub {
+            Subcommand::Add { common, .. } => common.log_dir,
+            Subcommand::Run { common, .. } => common.log_dir,
+        };
+        prepare_logging(&name, log_dir, console)?;
     }
 
     debug!("********** LAUNCH **********");
@@ -666,6 +683,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -697,6 +715,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -721,6 +740,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -745,6 +765,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -769,6 +790,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -793,6 +815,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -817,6 +840,7 @@ speculate::speculate! {
                                 stop_timeout: Some(500),
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -841,6 +865,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -867,6 +892,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -905,6 +931,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -929,6 +956,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -953,6 +981,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -977,6 +1006,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -1001,6 +1031,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -1025,6 +1056,7 @@ speculate::speculate! {
                                 stop_timeout: Some(500),
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -1049,6 +1081,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: true,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -1073,6 +1106,32 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: true,
+                                log_dir: None,
+                                command: vec![s("foo")],
+                                pass_start_args: false,
+                            }
+                        }
+                    },
+                );
+            }
+
+            it "accepts --log-dir" {
+                check_args(
+                    &["shawl", "run", "--log-dir", "C:\\any\\dir", "--", "foo"],
+                    Cli {
+                        sub: Subcommand::Run {
+                            name: s("Shawl"),
+                            cwd: None,
+                            common: CommonOpts {
+                                pass: None,
+                                restart: false,
+                                no_restart: false,
+                                restart_if: vec![],
+                                restart_if_not: vec![],
+                                stop_timeout: None,
+                                no_log: false,
+                                no_log_cmd: false,
+                                log_dir: Some("C:\\any\\dir".to_string()),
                                 command: vec![s("foo")],
                                 pass_start_args: false,
                             }
@@ -1097,6 +1156,7 @@ speculate::speculate! {
                                 stop_timeout: None,
                                 no_log: false,
                                 no_log_cmd: false,
+                                log_dir: None,
                                 command: vec![s("foo")],
                                 pass_start_args: true,
                             }
@@ -1155,6 +1215,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1177,6 +1238,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1199,6 +1261,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1221,6 +1284,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1243,6 +1307,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1265,6 +1330,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1287,6 +1353,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1309,6 +1376,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1331,6 +1399,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1353,6 +1422,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1375,6 +1445,7 @@ speculate::speculate! {
                         stop_timeout: Some(3000),
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1397,6 +1468,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1419,6 +1491,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1442,6 +1515,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: true,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
@@ -1463,11 +1537,58 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: true,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: false,
                     }
                 ),
                 vec!["run", "--name", "shawl", "--no-log-cmd"],
+            );
+        }
+
+        it "handles --log-dir without spaces" {
+            assert_eq!(
+                construct_shawl_run_args(
+                    &s("shawl"),
+                    &None,
+                    &CommonOpts {
+                        pass: None,
+                        restart: false,
+                        no_restart: false,
+                        restart_if: vec![],
+                        restart_if_not: vec![],
+                        stop_timeout: None,
+                        no_log: false,
+                        no_log_cmd: false,
+                        log_dir: Some("C:/foo".to_string()),
+                        command: vec![s("foo")],
+                        pass_start_args: false,
+                    }
+                ),
+                vec!["run", "--name", "shawl", "--log-dir", "C:/foo"],
+            );
+        }
+
+        it "handles --log-dir with spaces" {
+            assert_eq!(
+                construct_shawl_run_args(
+                    &s("shawl"),
+                    &None,
+                    &CommonOpts {
+                        pass: None,
+                        restart: false,
+                        no_restart: false,
+                        restart_if: vec![],
+                        restart_if_not: vec![],
+                        stop_timeout: None,
+                        no_log: false,
+                        no_log_cmd: false,
+                        log_dir: Some("C:/foo bar/hello".to_string()),
+                        command: vec![s("foo")],
+                        pass_start_args: false,
+                    }
+                ),
+                vec!["run", "--name", "shawl", "--log-dir", "\"C:/foo bar/hello\""],
             );
         }
 
@@ -1485,6 +1606,7 @@ speculate::speculate! {
                         stop_timeout: None,
                         no_log: false,
                         no_log_cmd: false,
+                        log_dir: None,
                         command: vec![s("foo")],
                         pass_start_args: true,
                     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,6 +12,20 @@ speculate::speculate! {
         format!("{}/target/debug/shawl_for_shawl_rCURRENT.log", env!("CARGO_MANIFEST_DIR"))
     }
 
+    fn log_file_custom_dir() -> String {
+        format!("{}/target/debug/log_dir/shawl_for_shawl_rCURRENT.log", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn log_custom_dir() -> String {
+        format!("{}/target/debug/log_dir", env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn delete_log_custom_dir() {
+        if std::path::Path::new(&log_custom_dir()).is_dir() {
+            std::fs::remove_dir_all(log_custom_dir()).unwrap();
+        }
+    }
+
     fn delete_log() {
         if log_exists() {
             std::fs::remove_file(log_file()).unwrap();
@@ -162,6 +176,19 @@ speculate::speculate! {
 
             let log = std::fs::read_to_string(log_file()).unwrap();
             assert!(!log.contains("shawl-child has started"));
+        }
+
+        it "creates log file in custom dir with --log-dir" {
+            delete_log();
+            delete_log_custom_dir();
+
+            run_shawl(&["add", "--name", "shawl", "--log-dir", &log_custom_dir(), "--", &child()]);
+            run_cmd(&["sc", "start", "shawl"]);
+            run_cmd(&["sc", "stop", "shawl"]);
+
+            let log = std::fs::read_to_string(log_file_custom_dir()).unwrap();
+            assert!(!log.contains("shawl-child has started"));
+            assert!(!log_exists()); // Ensure log file hasn't been created next to the .exe
         }
 
         it "can pass arguments through successfully" {


### PR DESCRIPTION
Added the feature suggested in #13 + added tests. Version bumped to v1.1.0

```
        --log-dir <log-dir>
            Write log file to a custom directory. This directory will be created
            if it doesn't exist
```