### PR TITLE
fix: Using log_dir causes log rotation to fail

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn prepare_logging(
 
     // Set custom log directory
     if let Some(dir) = log_dir {
-        logger = logger.o_directory(Some(dir));
+        logger = logger.o_directory(Some(dir.replace("\\\\?\\", "")));
     }
 
     if console {


### PR DESCRIPTION
fix using log_dir causes log rotation to fail