### PR TITLE
#74: add option to run as interactive, so we don't abort() throwing STACK_BUFFER_OVERRUN

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -284,6 +284,14 @@ pub struct CommonOpts {
     #[clap(long)]
     pub kill_process_tree: bool,
 
+    /// Abort shawl if ctrl-C or ctrl-Break is received unexpectedly.
+    /// Use this when running shawl directly from a terminal so that Ctrl+C stops it.
+    /// Or if you expect shawl to handle those ctrl c.
+    /// Using this as a service means that, when the service or the child receive ctrl c, 
+    /// it may throw an STACK_BUFFER_OVERRUN error to windows
+    #[clap(long)]
+    pub interactive: bool,
+
     /// Command to run as a service
     #[clap(required(true), last(true))]
     pub command: Vec<String>,
@@ -966,6 +974,23 @@ speculate::speculate! {
                         cwd: None,
                         common: CommonOpts {
                             kill_process_tree: true,
+                            command: vec![s("foo")],
+                            ..Default::default()
+                        }
+                    }
+                },
+            );
+        }
+
+        it "accepts --interactive" {
+            check_args(
+                &["shawl", "run", "--interactive", "--", "foo"],
+                Cli {
+                    sub: Subcommand::Run {
+                        name: s("Shawl"),
+                        cwd: None,
+                        common: CommonOpts {
+                            interactive: true,
                             command: vec![s("foo")],
                             ..Default::default()
                         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,7 +287,7 @@ pub struct CommonOpts {
     /// Abort shawl if ctrl-C or ctrl-Break is received unexpectedly.
     /// Use this when running shawl directly from a terminal so that Ctrl+C stops it.
     /// Or if you expect shawl to handle those ctrl c.
-    /// Using this as a service means that, when the service or the child receive ctrl c, 
+    /// Using this as a service means that, when the service or the child receive ctrl c,
     /// it may throw an STACK_BUFFER_OVERRUN error to windows
     #[clap(long)]
     pub interactive: bool,

--- a/src/control.rs
+++ b/src/control.rs
@@ -144,6 +144,9 @@ fn construct_shawl_run_args(name: &str, cwd: &Option<String>, opts: &CommonOpts)
     if opts.kill_process_tree {
         shawl_args.push("--kill-process-tree".to_string());
     }
+    if opts.interactive {
+        shawl_args.push("--interactive".to_string());
+    }
     shawl_args
 }
 
@@ -598,6 +601,20 @@ speculate::speculate! {
                     }
                 ),
                 vec!["run", "--name", "shawl", "--kill-process-tree"],
+            );
+        }
+
+        it "handles --interactive" {
+            assert_eq!(
+                construct_shawl_run_args(
+                    &s("shawl"),
+                    &None,
+                    &CommonOpts {
+                        interactive: true,
+                        ..Default::default()
+                    }
+                ),
+                vec!["run", "--name", "shawl", "--interactive"],
             );
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -88,12 +88,13 @@ pub fn run_service(start_arguments: Vec<std::ffi::OsString>) -> windows_service:
     };
     let pass = &opts.pass.unwrap_or_else(|| vec![0]);
     let stop_timeout = &opts.stop_timeout.unwrap_or(3000_u64);
+    let interactive = opts.interactive;
     let mut service_exit_code = ServiceExitCode::NO_ERROR;
 
     let ignore_ctrlc = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let ignore_ctrlc2 = ignore_ctrlc.clone();
     ctrlc::set_handler(move || {
-        if !ignore_ctrlc2.load(std::sync::atomic::Ordering::SeqCst) {
+        if interactive && !ignore_ctrlc2.load(std::sync::atomic::Ordering::SeqCst) {
             std::process::abort();
         }
     })


### PR DESCRIPTION
I'm sending this PR to fix #74.

The issue was that shawl was throwing STACK_BUFFER_OVERRUN error to windows, showing up in the event viewer. It happened randomly during a restart, but then I tried sending CTRL_BREAK_EVENT from the binary being run and it happened there too.

From what I see, there is no need for shawl to do something during events thrown from the console. It's already expected that, if shawl sent the event, it shouldn't do anything. Since these events are only thrown for the console, and the console is only there to send the event to the child program, I believe the rest of the events can be ignored too.

Here I've added a new flag --interactive, so it can be "interacted" through these events, just like it works now, but by default it won't do anything to handle control events.